### PR TITLE
feat: servicio y controlador de Adoptions y pets

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionRepository.java
@@ -12,4 +12,7 @@ public interface AdoptionRepository extends CrudRepository<AdoptionRequest, Inte
 	@Query("SELECT p FROM Pet p WHERE p.onAdoption = TRUE")
 	public List<Pet> findPetsOnAdoption();
 
+	@Query("SELECT ar FROM AdoptionRequest ar WHERE ar.originalOwner.id = ?1 AND ar.active = TRUE")
+	public List<AdoptionRequest> findAllByOriginalOwner(Integer id);
+
 }

--- a/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionRequest.java
+++ b/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionRequest.java
@@ -20,21 +20,18 @@ import lombok.Setter;
 @Setter
 public class AdoptionRequest extends BaseEntity{
 
-    @Column(name = "original_owner_id")
     @ManyToOne(optional = false)
-    @JoinColumn(name = "owner_id")
+    @JoinColumn(name = "original_owner_id")
     @NotNull
     private Owner originalOwner;
 
-    @Column(name = "new_owner_id")
     @ManyToOne(optional = false)
-    @JoinColumn(name = "owner_id")
+    @JoinColumn(name = "new_owner_id")
     @NotNull
     private Owner newOwner;
 
-    @Column(name = "pet_to_adopt_id")
     @ManyToOne(optional = false)
-    @JoinColumn(name = "pet_id")
+    @JoinColumn(name = "pet_to_adopt_id")
     @NotNull
     private Pet petToAdopt;
 

--- a/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionRequestForm.java
+++ b/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionRequestForm.java
@@ -1,0 +1,17 @@
+package org.springframework.samples.petclinic.adoption;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdoptionRequestForm {
+    @NotBlank
+	private String description;
+
+	@NotNull
+	private Integer petId;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionRestController.java
@@ -1,0 +1,77 @@
+package org.springframework.samples.petclinic.adoption;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.user.UserService;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.samples.petclinic.user.User;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/adoptions")
+@Tag(name = "Adoptions", description = "The Adoptions managemet API")
+@SecurityRequirement(name = "bearerAuth")
+public class AdoptionRestController {
+    private final AdoptionService adoptionService;
+    private final UserService userService;
+
+	@Autowired
+	public AdoptionRestController(AdoptionService adoptionService, UserService userService) {
+		this.adoptionService = adoptionService;
+        this.userService = userService;
+	}
+
+    @GetMapping
+	public ResponseEntity<?> findMyAdoptionRequests() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        User user = userService.findUser(auth.getName());
+        try{
+            List<AdoptionRequest> adoptionRequests = adoptionService.findAllByOriginalOwner(user.getId());
+            return new ResponseEntity<>(adoptionRequests, HttpStatus.OK);
+        }
+        catch(Exception e){
+            return new ResponseEntity<>(e.getMessage(),HttpStatus.NOT_FOUND);
+        }
+	}
+
+    @GetMapping("/accept/{id}")
+	public ResponseEntity<?> acceptAdoptionRequest(@PathVariable("id") int id) {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        User user = userService.findUser(auth.getName());
+        try{
+            AdoptionRequest adoptionRequests = adoptionService.acceptAdoptionRequest(id,user);
+            return new ResponseEntity<>(adoptionRequests, HttpStatus.OK);
+        }
+        catch(Exception e){
+            return new ResponseEntity<>(e.getMessage(),HttpStatus.NOT_FOUND);
+        }
+	}
+
+    @PostMapping
+	public ResponseEntity<?> createAdoptionRequest(@RequestBody @Valid AdoptionRequestForm adoptionRequestForm) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        User user = userService.findUser(auth.getName());
+        try {
+            AdoptionRequest adoptionRequestSaved = adoptionService.save(adoptionRequestForm,user);
+            return new ResponseEntity<>(adoptionRequestSaved, HttpStatus.OK);
+        }
+        catch(Exception e) {
+            return new ResponseEntity<>(e.getMessage(),HttpStatus.NOT_FOUND);
+        }
+	}
+
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionService.java
+++ b/src/main/java/org/springframework/samples/petclinic/adoption/AdoptionService.java
@@ -1,0 +1,100 @@
+package org.springframework.samples.petclinic.adoption;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.samples.petclinic.owner.Owner;
+import org.springframework.samples.petclinic.owner.OwnerService;
+import org.springframework.samples.petclinic.pet.Pet;
+import org.springframework.samples.petclinic.pet.PetService;
+import org.springframework.samples.petclinic.user.User;
+import org.springframework.stereotype.Service;
+
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.dao.DataAccessException;
+
+@Service
+public class AdoptionService {
+    private AdoptionRepository adoptionRepository;
+    private OwnerService ownerService;
+    private PetService petService;
+
+    @Autowired
+	public AdoptionService(AdoptionRepository adoptionRepository, OwnerService ownerService, PetService petService) {
+		this.adoptionRepository = adoptionRepository;
+        this.ownerService = ownerService;
+        this.petService = petService;
+	}
+
+    @Transactional(readOnly = true)
+    public List<AdoptionRequest> findAll() throws DataAccessException {
+        return (List<AdoptionRequest>) adoptionRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdoptionRequest> findAllByOriginalOwner(Integer userId) throws DataAccessException {
+        Optional<Owner> owner = ownerService.optFindOwnerByUser(userId);
+        if(owner.isPresent()){
+            return (List<AdoptionRequest>) adoptionRepository.findAllByOriginalOwner(owner.get().getId());
+        }
+        else{
+            throw new DataAccessException("Owner not found"){};
+        }
+    }
+
+    @Transactional
+	public AdoptionRequest save(AdoptionRequestForm adoptionRequestForm, User userNewOwner) throws DataAccessException {
+        Optional<Owner> newOwner = ownerService.optFindOwnerByUser(userNewOwner.getId());
+        if(!newOwner.isPresent()){
+            throw new DataAccessException("The user is not an owner"){};
+        }
+
+        Pet pet = petService.findPetById(adoptionRequestForm.getPetId());
+        if(pet.getOwner().getId() == newOwner.get().getId()){
+            throw new DataAccessException("You cannot adopt your own pet"){};
+        }
+        if(!pet.getOnAdoption()){
+            throw new DataAccessException("Pet is not on adoption"){};
+        }
+        
+        AdoptionRequest adoptionRequest = new AdoptionRequest();
+        adoptionRequest.setOriginalOwner(pet.getOwner());
+        adoptionRequest.setNewOwner(newOwner.get());
+        adoptionRequest.setPetToAdopt(pet);
+        adoptionRequest.setDescription(adoptionRequestForm.getDescription());
+        adoptionRepository.save(adoptionRequest);
+
+        return adoptionRequest;
+	}
+
+    @Transactional
+    public AdoptionRequest acceptAdoptionRequest(Integer requestId, User userId) throws DataAccessException {
+
+        Optional<Owner> originalOwner = ownerService.optFindOwnerByUser(userId.getId());
+        if(!originalOwner.isPresent()){
+            throw new DataAccessException("The user is not an owner"){};
+        }
+
+        Optional<AdoptionRequest> adoptionRequest = adoptionRepository.findById(requestId);
+        if(!adoptionRequest.isPresent()){
+            throw new DataAccessException("Adoption Request not found"){};
+        }
+        AdoptionRequest adoptionRequestToAccept = adoptionRequest.get();
+
+        if(adoptionRequestToAccept.getOriginalOwner().getId() != originalOwner.get().getId()){
+            throw new DataAccessException("You are not the original owner of the pet"){};
+        }
+
+        Pet pet = adoptionRequestToAccept.getPetToAdopt();
+        pet.setOnAdoption(false);
+        pet.setOwner(adoptionRequestToAccept.getNewOwner());
+        petService.savePet(pet);
+
+        adoptionRequestToAccept.setAdmitted(true);
+        adoptionRequestToAccept.setActive(false);
+
+        return adoptionRepository.save(adoptionRequestToAccept);
+    }
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerService.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerService.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.clinic.PricingPlan;
 import org.springframework.samples.petclinic.exceptions.ResourceNotFoundException;
-import org.springframework.samples.petclinic.pet.PetService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,12 +36,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class OwnerService {
 
 	private OwnerRepository ownerRepository;
-	private PetService petService;
 
 	@Autowired
-	public OwnerService(OwnerRepository ownerRepository, PetService petService) {
+	public OwnerService(OwnerRepository ownerRepository) {
 		this.ownerRepository = ownerRepository;
-		this.petService = petService;
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/org/springframework/samples/petclinic/pet/PetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/pet/PetRepository.java
@@ -46,6 +46,9 @@ public interface PetRepository extends CrudRepository<Pet, Integer> {
 	@Query(("SELECT p FROM Pet p WHERE p.owner.user.id = :id"))
 	List<Pet> findAllPetsByUserId(int id);
 
+	@Query(("SELECT p FROM Pet p WHERE p.onAdoption = true"))
+	List<Pet> findAllPetsOnAdoption();
+
 	// STATS
 	// ADMIN
 	@Query("SELECT COUNT(p) FROM Pet p")

--- a/src/main/java/org/springframework/samples/petclinic/pet/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/pet/PetRestController.java
@@ -34,6 +34,8 @@ import org.springframework.samples.petclinic.pet.exceptions.DuplicatedPetNameExc
 import org.springframework.samples.petclinic.user.User;
 import org.springframework.samples.petclinic.user.UserService;
 import org.springframework.samples.petclinic.util.RestPreconditions;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -85,6 +87,24 @@ public class PetRestController {
 				return new ResponseEntity<>((List<Pet>) this.petService.findAll(), HttpStatus.OK);
 		}
 		throw new AccessDeniedException();
+	}
+
+	@GetMapping("onAdoption")
+	public ResponseEntity<List<Pet>> findAllOnAdoption() {
+		return new ResponseEntity<>(petService.findAllPetsOnAdoption(), HttpStatus.OK);
+	}
+
+	@GetMapping("onAdoption/{petId}")
+	public ResponseEntity<?> changeOnAdoption(@PathVariable("petId") int petId) {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        User user = userService.findUser(auth.getName());
+		try{
+			Pet pet = petService.changeOnAdoption(petId, user.getId());
+			return new ResponseEntity<>(pet, HttpStatus.OK);
+		}
+		catch(Exception e){
+			return new ResponseEntity<>(e.getMessage(),HttpStatus.BAD_REQUEST);
+		}
 	}
 
 	@GetMapping("types")

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -73,19 +73,19 @@ INSERT INTO owners(id, first_name, last_name, address, city, telephone, user_id,
 INSERT INTO owners(id, first_name, last_name, address, city, telephone, user_id, clinic) VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail','Cádiz', '685559435', 12, 3);
 INSERT INTO owners(id, first_name, last_name, address, city, telephone, user_id, clinic) VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Cádiz', '685555487', 13, 1);
 
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (1, 'Leo', '2010-09-07', 1, 1);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (2, 'Basil', '2012-08-06', 6, 2);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (3, 'Rosy', '2011-04-17', 2, 3);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (4, 'Jewel', '2010-03-07', 2, 3);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (5, 'Iggy', '2010-11-30', 3, 4);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (6, 'George', '2010-01-20', 4, 5);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (7, 'Samantha', '2012-09-04', 1, 6);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (8, 'Max', '2012-09-04', 1, 6);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (9, 'Lucky', '2011-08-06', 5, 7);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (10, 'Mulligan', '2007-02-24', 2, 8);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (11, 'Freddy', '2010-03-09', 5, 9);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (12, 'Lucky', '2010-06-24', 2, 10);
-INSERT INTO pets(id,name,birth_date,type_id,owner_id) VALUES (13, 'Sly', '2012-06-08', 1, 10);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (1, 'Leo', '2010-09-07', 1, 1,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (2, 'Basil', '2012-08-06', 6, 2,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (3, 'Rosy', '2011-04-17', 2, 3,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (4, 'Jewel', '2010-03-07', 2, 3,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (5, 'Iggy', '2010-11-30', 3, 4,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (6, 'George', '2010-01-20', 4, 5,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (7, 'Samantha', '2012-09-04', 1, 6,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (8, 'Max', '2012-09-04', 1, 6,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (9, 'Lucky', '2011-08-06', 5, 7,0);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (10, 'Mulligan', '2007-02-24', 2, 8,1);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (11, 'Freddy', '2010-03-09', 5, 9,1);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (12, 'Lucky', '2010-06-24', 2, 10,1);
+INSERT INTO pets(id,name,birth_date,type_id,owner_id,on_adoption) VALUES (13, 'Sly', '2012-06-08', 1, 10,1);
 
 INSERT INTO visits(id,pet_id,visit_date_time,description,vet_id) VALUES (1, 7, '2013-01-01 13:00', 'rabies shot', 4);
 INSERT INTO visits(id,pet_id,visit_date_time,description,vet_id) VALUES (2, 8, '2013-01-02 15:30', 'rabies shot', 5);
@@ -111,3 +111,5 @@ INSERT INTO consultation_tickets(id,description,creation_date, user_id, consulta
 INSERT INTO consultation_tickets(id,description,creation_date, user_id, consultation_id) VALUES (6, 'Try to give him some tuna to check if he eats that.', '2023-04-11 15:20', 15, 3);
 INSERT INTO consultation_tickets(id,description,creation_date, user_id, consultation_id) VALUES (7, 'My lovebird doesn''t sing as my neighbour''s one.', '2023-02-24 12:30', 5, 4);
 INSERT INTO consultation_tickets(id,description,creation_date, user_id, consultation_id) VALUES (8, 'Lovebirds do not sing.', '2023-02-24 18:30', 16, 4);
+
+INSERT INTO adoption_requests(id,pet_to_adopt_id,original_owner_id,new_owner_id,active,admitted,description) VALUES (1, 13, 10, 3,1, 1,'Description of the request');


### PR DESCRIPTION
Creación de los servicios y controladores para el listado, creación y acutalización de Adoptions. Creación de servicios y controladores para las mascotas en adopción.

Se han modificado algunos archivos ajenos a la implementación a causa de bugs:
- AdoptionRequest: daba error @Column por el @ManyToOne. Para nombrar una columna con una relación se usa @JoinColumn
- data.sql: al añadir on_adoption como @NotNull, era necesario añadir esa columna en los datos iniciales.
- OwnerService: petService no se usa y provoca un bucle de llamadas infinitas entre petService y ownerService.

Nuevas rutas añadidas:
- _GET /api/v1/pets/onAdoption_: lista las mascotas en adopción
- _GET /api/v1/pets/onAdoption/{petId}_: dado el id de una mascota, cambia su estado de onAdoption. Se cambia a false si estaba a true y viceversa
- _GET /api/v1/adoptions_: lista los adoption requests que se han enviado a tus mascotas
- _POST /api/v1/adoptions_: crea un adoption request hacia una mascota en adopción, dando el petId y una descripción
```json
{
    "description": "New description",
    "petId": 1
}
```
> Ejemplo de body
- _GET /api/v1/adoptions/accept/{adoptionRequestId}_: dado un id de un adoptionRequest, lo acepta
